### PR TITLE
delete default user guest & change permission level of new user

### DIFF
--- a/bin/rabbitmq-reload
+++ b/bin/rabbitmq-reload
@@ -16,11 +16,12 @@ if [ ! -f /var/lib/rabbitmq/reset ]; then
         # Give some time time for startup. (Need better way to handle this.)
         sleep 10s
         # Queues beginning with ha.* are highly available
+        rabbitmqctl delete_user guest
         rabbitmqctl set_cluster_name $RABBITMQ_CLUSTER_NAME
         rabbitmqctl set_policy ha-all "^ha\." '{"ha-mode":"all"}'
         rabbitmqctl add_user ${RABBITMQ_USER} ${RABBITMQ_PASSWORD}
         rabbitmqctl set_permissions -p / ${RABBITMQ_USER} ".*" ".*" ".*"
-        rabbitmqctl set_user_tags ${RABBITMQ_USER} monitoring
+        rabbitmqctl set_user_tags ${RABBITMQ_USER} administrator
     else
         rabbitmqctl stop_app
         rabbitmqctl reset

--- a/bin/rabbitmq-reload
+++ b/bin/rabbitmq-reload
@@ -1,7 +1,5 @@
 #!/bin/bash -el
 
-source /utils.sh
-
 NODE=$(cat /var/lib/rabbitmq/nodename)
 ETCDCTL="etcdctl --peers $ETCD_URL"
 # Set the nodename

--- a/bin/rabbitmq-reload
+++ b/bin/rabbitmq-reload
@@ -1,5 +1,7 @@
 #!/bin/bash -el
 
+source /utils.sh
+
 NODE=$(cat /var/lib/rabbitmq/nodename)
 ETCDCTL="etcdctl --peers $ETCD_URL"
 # Set the nodename


### PR DESCRIPTION
From security point of view, leaving  default user/password can expose the service to remote hostile take over.
After deleting the default user, the RABBITMQ_USER will be created under more restrict security profile terms.
